### PR TITLE
feat: create README.md for android mesh_service_example

### DIFF
--- a/android/meshtastic_service_example/README.md
+++ b/android/meshtastic_service_example/README.md
@@ -1,0 +1,7 @@
+# mesh_service_example
+
+This module provides an example implementation of an app that uses the [AIDL](https://developer.android.com/develop/background-work/services/aidl) Mesh Service provided by Meshtastic-Android project.
+
+Details are available here.
+
+[mesh_service_example](https://github.com/meshtastic/Meshtastic-Android/tree/main/mesh_service_example)


### PR DESCRIPTION
Adds a `README.md` that links to the android [mesh_service_example](https://github.com/meshtastic/Meshtastic-Android/tree/main/mesh_service_example) application module.